### PR TITLE
Use fail to signal an exception

### DIFF
--- a/guides/ruby.yml
+++ b/guides/ruby.yml
@@ -389,3 +389,7 @@ Style/DotPosition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains'
   Enabled: true
   EnforcedStyle: leading
+
+Style/SignalException:
+  Enabled: true
+  EnforcedStyle: semantic


### PR DESCRIPTION
Use fail to signal the exception, use raise to rethrow it after
rescueing

This was initially [Jim Weirich's](https://www.weirichfund.org/#about-jim) [idea](http://devblog.avdi.org/2014/05/21/jim-weirich-on-exceptions/)

The guy [knows his rubies](https://github.com/jimweirich/), and I think
we mutually agree it's kind of a good idea.